### PR TITLE
Upgraded to use array notation instead of object method call

### DIFF
--- a/IntegrationServices/PlatformVersionReader.php
+++ b/IntegrationServices/PlatformVersionReader.php
@@ -31,7 +31,7 @@ class PlatformVersionReader
      */
     public function getIntegrationVersion()
     {
-        return $this->packageProvider->getOroPackages()[$this->getIntegrationName()]->getFullPrettyVersion();
+        return $this->packageProvider->getOroPackages()[$this->getIntegrationName()]['pretty_version'];
     }
 
     /**
@@ -48,7 +48,7 @@ class PlatformVersionReader
             $molliePackage = $packageInterfaces['mollie/orocommerce'];
         }
 
-        return $molliePackage ? $molliePackage->getFullPrettyVersion() : null;
+        return $molliePackage ? $molliePackage->getFullPrettyVersion()['pretty_version'] : null;
     }
 
     /**


### PR DESCRIPTION
Oro 5.1 no longer uses objects for the packaging informations