### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/Controller/ActivePaymentMethodsController.php
+++ b/Controller/ActivePaymentMethodsController.php
@@ -9,7 +9,7 @@ use Mollie\Bundle\PaymentBundle\IntegrationCore\Infrastructure\Configuration\Con
 use Mollie\Bundle\PaymentBundle\IntegrationCore\Infrastructure\Logger\Logger;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class ActivePaymentMethodsController
@@ -41,12 +41,11 @@ class ActivePaymentMethodsController extends AbstractController
 
 
     /**
-     * @Route("/methods/active/{channelId}/{profileId}", name="mollie_active_payment_methods", methods={"GET"})
      *
      * @param string $profileId
-     *
      * @return JsonResponse
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/methods/active/{channelId}/{profileId}', name: 'mollie_active_payment_methods', methods: ['GET'])]
     public function getActivePaymentMethods($channelId, $profileId)
     {
         try {

--- a/Controller/AjaxMollieController.php
+++ b/Controller/AjaxMollieController.php
@@ -4,13 +4,13 @@ namespace Mollie\Bundle\PaymentBundle\Controller;
 
 use Oro\Bundle\IntegrationBundle\Entity\Channel;
 use Oro\Bundle\IntegrationBundle\Form\Type\ChannelType;
-use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
-use Oro\Bundle\SecurityBundle\Annotation\CsrfProtection;
+use Oro\Bundle\SecurityBundle\Attribute\AclAncestor;
+use Oro\Bundle\SecurityBundle\Attribute\CsrfProtection;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class AjaxMollieController
@@ -20,16 +20,14 @@ use Symfony\Component\Routing\Annotation\Route;
 class AjaxMollieController extends AbstractController
 {
     /**
-     * @Route("/validate-connection/{channelId}/", name="mollie_payment_validate_connection", methods={"POST"})
-     * @AclAncestor("oro_integration_update")
-     * @ParamConverter("channel", class="OroIntegrationBundle:Channel", options={"id" = "channelId"})
-     * @CsrfProtection()
-     *
      * @param Request      $request
      * @param Channel|null $channel
-     *
      * @return JsonResponse
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/validate-connection/{channelId}/', name: 'mollie_payment_validate_connection', methods: ['POST'])]
+    #[AclAncestor('oro_integration_update')]
+    #[ParamConverter('channel', class: 'OroIntegrationBundle:Channel', options: ['id' => 'channelId'])]
+    #[CsrfProtection]
     public function validateConnectionAction(Request $request, Channel $channel = null)
     {
         if (!$channel) {

--- a/Controller/PaymentLinkController.php
+++ b/Controller/PaymentLinkController.php
@@ -5,12 +5,12 @@ namespace Mollie\Bundle\PaymentBundle\Controller;
 use Mollie\Bundle\PaymentBundle\IntegrationCore\Infrastructure\Logger\Logger;
 use Mollie\Bundle\PaymentBundle\Manager\AdminLinkVisitHandler;
 use Oro\Bundle\OrderBundle\Entity\Order;
-use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
+use Oro\Bundle\SecurityBundle\Attribute\AclAncestor;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class PaymentLinkController
@@ -35,14 +35,14 @@ class PaymentLinkController extends AbstractController
     }
 
     /**
-     * @Route("/paymentlink/generate/{orderId}", name="mollie_payment_link", methods={"GET"})
-     * @ParamConverter("order", class="OroOrderBundle:Order", options={"id" = "orderId"})
      * @param Order $order
-     * @AclAncestor("oro_order_frontend_view")
      *
      * @return JsonResponse|RedirectResponse
      * @throws \Throwable
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/paymentlink/generate/{orderId}', name: 'mollie_payment_link', methods: ['GET'])]
+    #[ParamConverter('order', class: 'OroOrderBundle:Order', options: ['id' => 'orderId'])]
+    #[AclAncestor('oro_order_frontend_view')]
     public function goToMolliePaymentPage(Order $order)
     {
         try {

--- a/Controller/SupportController.php
+++ b/Controller/SupportController.php
@@ -4,11 +4,11 @@ namespace Mollie\Bundle\PaymentBundle\Controller;
 
 use Mollie\Bundle\PaymentBundle\IntegrationCore\Infrastructure\Configuration\Configuration;
 use Mollie\Bundle\PaymentBundle\IntegrationServices\DebugService;
-use Oro\Bundle\SecurityBundle\Annotation\Acl;
+use Oro\Bundle\SecurityBundle\Attribute\Acl;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -37,49 +37,30 @@ class SupportController extends AbstractController
     }
 
     /**
-     * @Route(
-     *     "/support/status",
-     *     name="mollie_payment_support_status",
-     *     methods={"GET"}
-     * )
-     *
-     * @Acl(
-     *      id="oro_integration_view",
-     *      type="entity",
-     *      permission="VIEW",
-     *      class="OroIntegrationBundle:Channel"
-     * )
      *
      * @return JsonResponse
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/support/status', name: 'mollie_payment_support_status', methods: ['GET'])]
+    #[Acl(id: 'oro_integration_view', type: 'entity', permission: 'VIEW', class: 'OroIntegrationBundle:Channel')]
     public function getDebugStatus()
     {
         return new JsonResponse(['isDebugModeEnabled' => $this->configService->isDebugModeEnabled()]);
     }
 
     /**
-     * @Route(
-     *     "/support/status",
-     *     name="mollie_payment_support_status_update",
-     *     methods={"POST"}
-     * )
      *
-     * @Acl(
-     *      id="oro_integration_view",
-     *      type="entity",
-     *      permission="VIEW",
-     *      class="OroIntegrationBundle:Channel"
-     * )
      *
      * @param Request $request
      * @return JsonResponse
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/support/status', name: 'mollie_payment_support_status_update', methods: ['POST'])]
+    #[Acl(id: 'oro_integration_view', type: 'entity', permission: 'VIEW', class: 'OroIntegrationBundle:Channel')]
     public function updateDebugStatus(Request $request)
     {
         $content = $request->getContent();
         $data = json_decode($content, true);
         if (!isset($data['debugStatus']) || !is_bool($data['debugStatus'])) {
-            return new JsonResponse(['success' => false], 400);
+            return new JsonResponse(['success' => false], \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST);
         }
 
         $this->configService->setDebugModeEnabled($data['debugStatus']);
@@ -88,21 +69,11 @@ class SupportController extends AbstractController
     }
 
     /**
-     * @Route(
-     *     "/support/download_debug_data",
-     *     name="mollie_payment_support_download_debug",
-     *     methods={"GET"}
-     * )
-     *
-     * @Acl(
-     *      id="oro_integration_view",
-     *      type="entity",
-     *      permission="VIEW",
-     *      class="OroIntegrationBundle:Channel"
-     * )
      *
      * @return BinaryFileResponse
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/support/download_debug_data', name: 'mollie_payment_support_download_debug', methods: ['GET'])]
+    #[Acl(id: 'oro_integration_view', type: 'entity', permission: 'VIEW', class: 'OroIntegrationBundle:Channel')]
     public function downloadDebugData()
     {
         /** @var DebugService $debugService */

--- a/Entity/ChannelSettings.php
+++ b/Entity/ChannelSettings.php
@@ -9,18 +9,14 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 
 /**
  * Entity with settings for Mollie integration
- *
- * @ORM\Entity(
- *     repositoryClass="Mollie\Bundle\PaymentBundle\Entity\Repository\ChannelSettingsRepository"
- * )
  */
+#[ORM\Entity(repositoryClass: \Mollie\Bundle\PaymentBundle\Entity\Repository\ChannelSettingsRepository::class)]
 class ChannelSettings extends Transport
 {
     /**
      * @var string
-     *
-     * @ORM\Column(name="mollie_save_marker", type="string", length=255, nullable=false)
      */
+    #[ORM\Column(name: 'mollie_save_marker', type: 'string', length: 255, nullable: false)]
     protected $mollieSaveMarker;
 
     /**
@@ -37,11 +33,8 @@ class ChannelSettings extends Transport
     private $websiteProfile;
     /**
      * @var \Mollie\Bundle\PaymentBundle\Entity\PaymentMethodSettings[]|\Doctrine\Common\Collections\ArrayCollection
-     *
-     * @ORM\OneToMany(targetEntity="Mollie\Bundle\PaymentBundle\Entity\PaymentMethodSettings",
-     *     mappedBy="channelSettings", cascade={"ALL"}, orphanRemoval=true
-     * )
      */
+    #[ORM\OneToMany(targetEntity: \Mollie\Bundle\PaymentBundle\Entity\PaymentMethodSettings::class, mappedBy: 'channelSettings', cascade: ['ALL'], orphanRemoval: true)]
     protected $paymentMethodSettings;
     /**
      * @var ParameterBag

--- a/Entity/MollieBaseEntity.php
+++ b/Entity/MollieBaseEntity.php
@@ -7,98 +7,82 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Class MollieBaseEntity Entity with settings for base Mollie ORM models
  * @package Mollie\Bundle\PaymentBundle\Entity
- *
- * @ORM\Table(
- *      name="mollie_entity",
- *      indexes={
- *          @ORM\Index(name="mollie_entity_type_idx", columns={"type"}),
- *          @ORM\Index(name="mollie_entity_type_index1_idx", columns={"type", "index1"}),
- *          @ORM\Index(name="mollie_entity_type_index2_idx", columns={"type", "index2"}),
- *          @ORM\Index(name="mollie_entity_type_index3_idx", columns={"type", "index3"}),
- *          @ORM\Index(name="mollie_entity_type_index4_idx", columns={"type", "index4"}),
- *          @ORM\Index(name="mollie_entity_type_index5_idx", columns={"type", "index5"}),
- *          @ORM\Index(name="mollie_entity_type_index6_idx", columns={"type", "index6"}),
- *          @ORM\Index(name="mollie_entity_type_index7_idx", columns={"type", "index7"}),
- *          @ORM\Index(name="mollie_entity_type_context_index1_idx", columns={"type", "context", "index1"}),
- *          @ORM\Index(name="mollie_entity_type_context_index2_idx", columns={"type", "context", "index2"}),
- *          @ORM\Index(name="mollie_entity_type_context_index3_idx", columns={"type", "context", "index3"}),
- *          @ORM\Index(name="mollie_entity_type_context_index4_idx", columns={"type", "context", "index4"}),
- *          @ORM\Index(name="mollie_entity_type_context_index5_idx", columns={"type", "context", "index5"}),
- *          @ORM\Index(name="mollie_entity_type_context_index6_idx", columns={"type", "context", "index6"}),
- *          @ORM\Index(name="mollie_entity_type_context_index7_idx", columns={"type", "context", "index7"})
- *      }
- * )
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'mollie_entity')]
+#[ORM\Index(name: 'mollie_entity_type_idx', columns: ['type'])]
+#[ORM\Index(name: 'mollie_entity_type_index1_idx', columns: ['type', 'index1'])]
+#[ORM\Index(name: 'mollie_entity_type_index2_idx', columns: ['type', 'index2'])]
+#[ORM\Index(name: 'mollie_entity_type_index3_idx', columns: ['type', 'index3'])]
+#[ORM\Index(name: 'mollie_entity_type_index4_idx', columns: ['type', 'index4'])]
+#[ORM\Index(name: 'mollie_entity_type_index5_idx', columns: ['type', 'index5'])]
+#[ORM\Index(name: 'mollie_entity_type_index6_idx', columns: ['type', 'index6'])]
+#[ORM\Index(name: 'mollie_entity_type_index7_idx', columns: ['type', 'index7'])]
+#[ORM\Index(name: 'mollie_entity_type_context_index1_idx', columns: ['type', 'context', 'index1'])]
+#[ORM\Index(name: 'mollie_entity_type_context_index2_idx', columns: ['type', 'context', 'index2'])]
+#[ORM\Index(name: 'mollie_entity_type_context_index3_idx', columns: ['type', 'context', 'index3'])]
+#[ORM\Index(name: 'mollie_entity_type_context_index4_idx', columns: ['type', 'context', 'index4'])]
+#[ORM\Index(name: 'mollie_entity_type_context_index5_idx', columns: ['type', 'context', 'index5'])]
+#[ORM\Index(name: 'mollie_entity_type_context_index6_idx', columns: ['type', 'context', 'index6'])]
+#[ORM\Index(name: 'mollie_entity_type_context_index7_idx', columns: ['type', 'context', 'index7'])]
 class MollieBaseEntity
 {
     /**
      * @var integer $id
-     *
-     * @ORM\Column(name="id", type="integer", nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'id', type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     protected $id;
     /**
      * @var string $type
-     *
-     * @ORM\Column(name="type", type="string", length=128, nullable=false)
      */
+    #[ORM\Column(name: 'type', type: 'string', length: 128, nullable: false)]
     protected $type;
     /**
      * @var string $context
-     *
-     * @ORM\Column(name="context", type="string", length=128, nullable=true)
      */
+    #[ORM\Column(name: 'context', type: 'string', length: 128, nullable: true)]
     protected $context;
     /**
      * @var string $index1
-     *
-     * @ORM\Column(name="index1", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name: 'index1', type: 'string', length: 255, nullable: true)]
     protected $index1;
     /**
      * @var string $index2
-     *
-     * @ORM\Column(name="index2", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name: 'index2', type: 'string', length: 255, nullable: true)]
     protected $index2;
     /**
      * @var string $index3
-     *
-     * @ORM\Column(name="index3", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name: 'index3', type: 'string', length: 255, nullable: true)]
     protected $index3;
     /**
      * @var string $index4
-     *
-     * @ORM\Column(name="index4", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name: 'index4', type: 'string', length: 255, nullable: true)]
     protected $index4;
     /**
      * @var string $index5
-     *
-     * @ORM\Column(name="index5", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name: 'index5', type: 'string', length: 255, nullable: true)]
     protected $index5;
     /**
      * @var string $index6
-     *
-     * @ORM\Column(name="index6", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name: 'index6', type: 'string', length: 255, nullable: true)]
     protected $index6;
     /**
      * @var string $index7
-     *
-     * @ORM\Column(name="index7", type="string", length=255, nullable=true)
      */
+    #[ORM\Column(name: 'index7', type: 'string', length: 255, nullable: true)]
     protected $index7;
     /**
      * @var string $data
-     *
-     * @ORM\Column(name="data", type="text", nullable=false)
      */
+    #[ORM\Column(name: 'data', type: 'text', nullable: false)]
     protected $data;
 
     /**

--- a/Entity/PaymentMethodSettings.php
+++ b/Entity/PaymentMethodSettings.php
@@ -10,161 +10,77 @@ use Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue;
 /**
  * Class PaymentMethodSettings Entity with settings for Mollie payment methods
  * @package Mollie\Bundle\PaymentBundle\Entity
- *
- * @ORM\Table(name="mollie_payment_settings")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'mollie_payment_settings')]
 class PaymentMethodSettings
 {
     /**
      * @var integer $id
-     *
-     * @ORM\Column(name="id", type="integer", nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'id', type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     protected $id;
 
     /**
      * @var \Mollie\Bundle\PaymentBundle\Entity\ChannelSettings
-     *
-     * @ORM\ManyToOne(targetEntity="Mollie\Bundle\PaymentBundle\Entity\ChannelSettings", inversedBy="paymentMethodSettings", cascade={"persist"})
-     * @ORM\JoinColumn(name="transport_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[ORM\ManyToOne(targetEntity: \Mollie\Bundle\PaymentBundle\Entity\ChannelSettings::class, inversedBy: 'paymentMethodSettings', cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'transport_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected $channelSettings;
 
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="mollie_payment_settings_name",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="payment_setting_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
      */
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'mollie_payment_settings_name', joinColumns: [new ORM\JoinColumn(name: 'payment_setting_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     protected $names;
 
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="mollie_payment_settings_desc",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="payment_setting_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
      */
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'mollie_payment_settings_desc', joinColumns: [new ORM\JoinColumn(name: 'payment_setting_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     protected $descriptions;
 
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="mollie_payment_settings_p_des",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="payment_setting_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
      */
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'mollie_payment_settings_p_des', joinColumns: [new ORM\JoinColumn(name: 'payment_setting_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     protected $paymentDescriptions;
 
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="mollie_payment_trans_desc",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="payment_setting_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
      */
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'mollie_payment_trans_desc', joinColumns: [new ORM\JoinColumn(name: 'payment_setting_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     protected $transactionDescriptions;
 
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="mollie_method_id", type="string", length=255, nullable=false)
      */
+    #[ORM\Column(name: 'mollie_method_id', type: 'string', length: 255, nullable: false)]
     protected $mollieMethodId;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="mollie_method_description", type="string", length=255, nullable=false)
      */
+    #[ORM\Column(name: 'mollie_method_description', type: 'string', length: 255, nullable: false)]
     protected $mollieMethodDescription;
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="mollie_payment_single_click_approval_text",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="payment_setting_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
      */
-
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'mollie_payment_single_click_approval_text', joinColumns: [new ORM\JoinColumn(name: 'payment_setting_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     protected $singleClickPaymentApprovalText;
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="mollie_payment_single_click_desc",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="payment_setting_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
      */
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'mollie_payment_single_click_desc', joinColumns: [new ORM\JoinColumn(name: 'payment_setting_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     protected $singleClickPaymentDescription;
     /**
      * @var \Mollie\Bundle\PaymentBundle\IntegrationCore\BusinessLogic\PaymentMethod\Model\PaymentMethodConfig

--- a/EventListener/Callback/AdminLinkPaymentRedirectListener.php
+++ b/EventListener/Callback/AdminLinkPaymentRedirectListener.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class AdminLinkPaymentRedirectListener
 {
-    /** @var Session */
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
     private $session;
     /**
      * @var RouterInterface
@@ -32,12 +32,12 @@ class AdminLinkPaymentRedirectListener
     /**
      * AdminLinkPaymentRedirectListener constructor.
      *
-     * @param Session $session
+     * @param \Symfony\Component\HttpFoundation\RequestStack $session
      * @param RouterInterface $router
      * @param TranslatorInterface $translator
      */
     public function __construct(
-        Session $session,
+        \Symfony\Component\HttpFoundation\RequestStack $session,
         RouterInterface $router,
         TranslatorInterface $translator
     ) {

--- a/EventListener/Callback/PaymentCheckoutCallbackListener.php
+++ b/EventListener/Callback/PaymentCheckoutCallbackListener.php
@@ -105,7 +105,7 @@ class PaymentCheckoutCallbackListener
                 return;
             }
 
-            if (!$this->request->getMasterRequest()) {
+            if (!$this->request->getMainRequest()) {
                 Logger::logWarning(
                     'Web hook without master HTTP request detected.',
                     'Integration',
@@ -133,7 +133,7 @@ class PaymentCheckoutCallbackListener
 
             /** @var MolliePayment $paymentMethod */
             $paymentMethod = $this->paymentMethodProvider->getPaymentMethod($paymentMethodId);
-            $webHookPayload = $this->request->getMasterRequest()->getContent();
+            $webHookPayload = $this->request->getMainRequest()->getContent();
 
             /** @var Order $order */
             $order = $this->doctrineHelper->getEntity(

--- a/EventListener/Callback/PaymentCheckoutRedirectListener.php
+++ b/EventListener/Callback/PaymentCheckoutRedirectListener.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class PaymentCheckoutRedirectListener
 {
-    /** @var Session */
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
     private $session;
 
     /**
@@ -45,14 +45,14 @@ class PaymentCheckoutRedirectListener
     /**
      * PaymentCheckoutRedirectListener constructor.
      *
-     * @param Session $session
+     * @param \Symfony\Component\HttpFoundation\RequestStack $session
      * @param PaymentMethodProviderInterface $paymentMethodProvider
      * @param PaymentResultMessageProviderInterface $messageProvider
      * @param DoctrineHelper $doctrineHelper
      * @param RouterInterface $router
      */
     public function __construct(
-        Session $session,
+        \Symfony\Component\HttpFoundation\RequestStack $session,
         PaymentMethodProviderInterface $paymentMethodProvider,
         PaymentResultMessageProviderInterface $messageProvider,
         DoctrineHelper $doctrineHelper,

--- a/EventListener/KernelEventListener.php
+++ b/EventListener/KernelEventListener.php
@@ -27,7 +27,7 @@ class KernelEventListener
                         'success' => false,
                         'message' => $exception->getMessage(),
                     ],
-                    422
+                    \Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY
                 )
             );
         }

--- a/Form/EventListener/ChannelSettingsTypeSubscriber.php
+++ b/Form/EventListener/ChannelSettingsTypeSubscriber.php
@@ -93,7 +93,7 @@ class ChannelSettingsTypeSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA  => [['onPreSetData', 10], ['setWebsiteProfile']],

--- a/Form/Type/ChannelSettingsType.php
+++ b/Form/Type/ChannelSettingsType.php
@@ -89,7 +89,7 @@ class ChannelSettingsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::BLOCK_PREFIX;
     }

--- a/Form/Type/MolliePasswordType.php
+++ b/Form/Type/MolliePasswordType.php
@@ -106,7 +106,7 @@ class MolliePasswordType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return PasswordType::class;
     }
@@ -114,7 +114,7 @@ class MolliePasswordType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'oro_placeholder_password';
     }

--- a/Form/Type/MollieRefundType.php
+++ b/Form/Type/MollieRefundType.php
@@ -80,7 +80,7 @@ class MollieRefundType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/Form/Type/PaymentMethodSettingsType.php
+++ b/Form/Type/PaymentMethodSettingsType.php
@@ -376,7 +376,7 @@ class PaymentMethodSettingsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::BLOCK_PREFIX;
     }

--- a/IntegrationCore/Infrastructure/ORM/Entity.php
+++ b/IntegrationCore/Infrastructure/ORM/Entity.php
@@ -118,16 +118,16 @@ abstract class Entity
     public function getIndexValue($indexKey)
     {
         $methodName = 'get' . ucfirst($indexKey);
-        if (method_exists($this, $methodName)) {
+        if (\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($this, $methodName)) {
             return $this->$methodName();
         }
 
         $methodName = 'is' . ucfirst($indexKey);
-        if (method_exists($this, $methodName)) {
+        if (\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($this, $methodName)) {
             return $this->$methodName();
         }
 
-        if (property_exists($this, $indexKey)) {
+        if (\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::propertyExists($this, $indexKey)) {
             return $this->$indexKey;
         }
 

--- a/Manager/ProductAttributeResolver.php
+++ b/Manager/ProductAttributeResolver.php
@@ -67,7 +67,7 @@ class ProductAttributeResolver
      */
     protected function getCategoryValue($category)
     {
-        if (is_object($category) && method_exists($category, 'getId')) {
+        if (is_object($category) && \Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($category, 'getId')) {
             return $category->getId();
         }
 
@@ -81,19 +81,19 @@ class ProductAttributeResolver
      */
     protected function getPropertyGetterName()
     {
-        if (method_exists($this->product, $this->productProperty)) {
+        if (\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($this->product, $this->productProperty)) {
             return $this->productProperty;
         }
 
-        if (method_exists($this->product, "get$this->productProperty")) {
+        if (\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($this->product, "get$this->productProperty")) {
             return "get$this->productProperty";
         }
 
-        if (method_exists($this->product, 'get' . MethodNameGenerator::fromSnakeCase($this->productProperty))) {
+        if (\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($this->product, 'get' . MethodNameGenerator::fromSnakeCase($this->productProperty))) {
             return 'get' . MethodNameGenerator::fromSnakeCase($this->productProperty);
         }
 
-        if (method_exists($this->product, 'get' . MethodNameGenerator::fromSnakeCase($this->productProperty, false))) {
+        if (\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($this->product, 'get' . MethodNameGenerator::fromSnakeCase($this->productProperty, false))) {
             return 'get' . MethodNameGenerator::fromSnakeCase($this->productProperty, false);
         }
 

--- a/MolliePaymentBundle.php
+++ b/MolliePaymentBundle.php
@@ -24,7 +24,7 @@ class MolliePaymentBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?\Symfony\Component\DependencyInjection\Extension\ExtensionInterface
     {
         if (!$this->extension) {
             $this->extension = new PaymentExtension();

--- a/PaymentMethod/MolliePayment.php
+++ b/PaymentMethod/MolliePayment.php
@@ -84,7 +84,7 @@ class MolliePayment implements PaymentMethodInterface, PurchaseActionInterface, 
      */
     public function execute($action, PaymentTransaction $paymentTransaction)
     {
-        if (!method_exists($this, $action)) {
+        if (!\Oro\Bundle\EntityExtendBundle\EntityPropertyInfo::methodExists($this, $action)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     '"%s" payment method "%s" action is not supported',

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "mollie/orocommerce",
-  "version": "5.0.10",
+  "version": "6.0.0",
   "type": "symfony-bundle",
   "description": "Mollie Payment Module for OroCommerce",
   "keywords": [
@@ -49,8 +49,8 @@
     "AFL-3.0"
   ],
   "require": {
-    "php": ">=8.1",
-    "oro/commerce": "^5.0"
+    "php": "~8.3.0",
+    "oro/commerce": "6.0.*"
   },
   "autoload": {
     "psr-4": { "Mollie\\Bundle\\PaymentBundle\\": "" }


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/commerce 6.0.*
- oro/upgrade-toolkit automatic migrations applied
