### PR TITLE
Fix MollieProductAttribute initialization by adding getDependencies method

### DIFF
--- a/Migrations/Data/ORM/MollieProductAttribute.php
+++ b/Migrations/Data/ORM/MollieProductAttribute.php
@@ -1,6 +1,7 @@
 <?php
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mollie\Bundle\PaymentBundle\IntegrationCore\BusinessLogic\PaymentMethod\Model\PaymentMethodConfig;
 use Oro\Bundle\EntityConfigBundle\Attribute\Entity\AttributeFamily;
@@ -16,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 /**
  * Class MollieProductAttribute
  */
-class MollieProductAttribute extends AbstractFixture implements ContainerAwareInterface
+class MollieProductAttribute extends AbstractFixture implements ContainerAwareInterface, DependentFixtureInterface
 {
     use MakeProductAttributesTrait;
 
@@ -106,5 +107,12 @@ class MollieProductAttribute extends AbstractFixture implements ContainerAwareIn
             $manager->persist($defaultFamily);
             $manager->flush();
         }
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            LoadProductDefaultAttributeFamilyData::class,
+        ];
     }
 }


### PR DESCRIPTION
Fix null reference error in MollieProductAttribute by adding getDependencies method

Added the getDependencies method to ensure the required data fixtures are loaded before MollieProductAttribute is initialized. This prevents a null reference error during container compilation when running a fresh OroCommerce installation.

Note: This issue only occurs during a clean install (`console oro:install --env=dev --timeout=0`) where the 'LoadProductDefaultAttributeFamilyData' fixture has not yet been loaded. In existing projects, this fixture is already present, so the error does not occur.