### PR TITLE
Fix: Fall back to CustomerUser name for B2B addresses

### DIFF
--- a/Mapper/MollieDtoMapper.php
+++ b/Mapper/MollieDtoMapper.php
@@ -203,6 +203,18 @@ class MollieDtoMapper implements MollieDtoMapperInterface
             ),
         ]);
 
+        // Fall back to CustomerUser name when address has no first/last name (common in B2B)
+        $customerUser = $order->getCustomerUser();
+        $mollieAddress = $orderData->getBillingAddress();
+        if (
+            $customerUser
+            && ((string) $billingAddress->getFirstName() === '' || (string) $billingAddress->getLastName() === '')
+        ) {
+            $mollieAddress->setGivenName($customerUser->getFirstName());
+            $mollieAddress->setFamilyName($customerUser->getLastName());
+            $orderData->setBillingAddress($mollieAddress);
+        }
+
         $orderData->setLines(
             array_merge(
                 $this->getOrderLinesData($orderLines),
@@ -212,6 +224,16 @@ class MollieDtoMapper implements MollieDtoMapperInterface
 
         if ($shippingAddress = $order->getShippingAddress()) {
             $orderData->setShippingAddress($this->getAddressData($shippingAddress, $order->getEmail()));
+
+            if (
+                $customerUser
+                && ((string) $shippingAddress->getFirstName() === '' || (string) $shippingAddress->getLastName() === '')
+            ) {
+                $mollieShipping = $orderData->getShippingAddress();
+                $mollieShipping->setGivenName($customerUser->getFirstName());
+                $mollieShipping->setFamilyName($customerUser->getLastName());
+                $orderData->setShippingAddress($mollieShipping);
+            }
         }
 
         if ($frontendOwner = $paymentTransaction->getFrontendOwner()) {


### PR DESCRIPTION
## Summary

- When billing or shipping address has no first/last name (common in B2B with ERP-imported addresses), fall back to the `CustomerUser`'s name
- The Mollie API requires `givenName` and `familyName` — empty values cause incomplete order data

## Changes

- `Mapper/MollieDtoMapper.php`: After building the order DTO, check if the source `OrderAddress` has empty first/last name, and if so, set `givenName`/`familyName` from the order's `CustomerUser`
- Applied to both billing and shipping addresses

## Test plan

- [ ] Place an order with a B2B customer whose address has only an organization name (no first/last name)
- [ ] Verify the Mollie order contains the `CustomerUser`'s name as `givenName`/`familyName`
- [ ] Verify B2C orders with populated address names are unaffected

Closes #54