### PR TITLE
Fix: Surcharges not shown due to interface check failing on entity proxies

### DIFF
--- a/EventListener/CheckoutEntityListener.php
+++ b/EventListener/CheckoutEntityListener.php
@@ -2,11 +2,11 @@
 
 namespace Mollie\Bundle\PaymentBundle\EventListener;
 
-use Mollie\Bundle\PaymentBundle\Entity\MollieSurchargeAwareInterface;
 use Mollie\Bundle\PaymentBundle\IntegrationCore\BusinessLogic\Surcharge\SurchargeService;
 use Mollie\Bundle\PaymentBundle\IntegrationCore\Infrastructure\ServiceRegister;
 use Mollie\Bundle\PaymentBundle\PaymentMethod\Config\Provider\MolliePaymentConfigProviderInterface;
 use Oro\Bundle\CheckoutBundle\Entity\Checkout;
+use Oro\Bundle\EntityExtendBundle\EntityPropertyInfo;
 
 /**
  * Class CheckoutEntityListener
@@ -46,7 +46,7 @@ class CheckoutEntityListener
      */
     protected function setSurcharge(Checkout $checkout)
     {
-        if (!$checkout instanceof MollieSurchargeAwareInterface) {
+        if (!EntityPropertyInfo::methodExists($checkout, 'setMollieSurchargeAmount')) {
             return;
         }
 

--- a/Mapper/OrderMapperDecorator.php
+++ b/Mapper/OrderMapperDecorator.php
@@ -2,9 +2,9 @@
 
 namespace Mollie\Bundle\PaymentBundle\Mapper;
 
-use Mollie\Bundle\PaymentBundle\Entity\MollieSurchargeAwareInterface;
 use Oro\Bundle\CheckoutBundle\Entity\Checkout;
 use Oro\Bundle\CheckoutBundle\Mapper\MapperInterface;
+use Oro\Bundle\EntityExtendBundle\EntityPropertyInfo;
 
 /**
  * Class OrderMapperDecorator
@@ -32,10 +32,11 @@ class OrderMapperDecorator implements MapperInterface
     public function map(Checkout $checkout, array $data = [], array $skipped = [])
     {
         $skipped['mollieSurchargeAmount'] = true;
-        /** @var MollieSurchargeAwareInterface $order */
         $order = $this->orderMapper->map($checkout, $data, $skipped);
 
-        if ($checkout instanceof MollieSurchargeAwareInterface) {
+        if (EntityPropertyInfo::methodExists($checkout, 'getMollieSurchargeAmount')
+            && EntityPropertyInfo::methodExists($order, 'setMollieSurchargeAmount')
+        ) {
             $order->setMollieSurchargeAmount($checkout->getMollieSurchargeAmount());
         }
 

--- a/Provider/MollieSurchargeProvider.php
+++ b/Provider/MollieSurchargeProvider.php
@@ -2,9 +2,9 @@
 
 namespace Mollie\Bundle\PaymentBundle\Provider;
 
-use Mollie\Bundle\PaymentBundle\Entity\MollieSurchargeAwareInterface;
 use Oro\Bundle\CheckoutBundle\DataProvider\Converter\CheckoutToOrderConverter;
 use Oro\Bundle\CurrencyBundle\Rounding\RoundingServiceInterface;
+use Oro\Bundle\EntityExtendBundle\EntityPropertyInfo;
 use Oro\Bundle\PricingBundle\SubtotalProcessor\Model\Subtotal;
 use Oro\Bundle\PricingBundle\SubtotalProcessor\Model\SubtotalProviderInterface;
 use Oro\Bundle\PricingBundle\SubtotalProcessor\Provider\AbstractSubtotalProvider;
@@ -66,7 +66,7 @@ class MollieSurchargeProvider extends AbstractSubtotalProvider implements Subtot
     }
 
     /**
-     * @param MollieSurchargeAwareInterface $entity
+     * @param object $entity
      *
      * @return Subtotal
      * @throws \Oro\Bundle\CurrencyBundle\Exception\InvalidRoundingTypeException
@@ -101,7 +101,6 @@ class MollieSurchargeProvider extends AbstractSubtotalProvider implements Subtot
      */
     public function isSupported($entity)
     {
-        // return $entity instanceof Checkout;
-        return $entity instanceof MollieSurchargeAwareInterface;
+        return EntityPropertyInfo::methodExists($entity, 'getMollieSurchargeAmount');
     }
 }


### PR DESCRIPTION
## Summary

- Since OroCommerce 5.1, the entity extension system no longer generates intermediate proxy classes for standard entities
- `MollieSurchargeAwareInterface` injected via `EntityGeneratorExtension` is no longer present on proxy classes
- All `instanceof MollieSurchargeAwareInterface` checks return `false`, so surcharges are never calculated or displayed

## Changes

Replace `instanceof MollieSurchargeAwareInterface` with `EntityPropertyInfo::methodExists()` — the recommended OroCommerce 5.1+ approach for checking extended entity capabilities:

- `EventListener/CheckoutEntityListener.php`: Guard `setSurcharge()` with capability check
- `Provider/MollieSurchargeProvider.php`: `isSupported()` uses capability check
- `Mapper/OrderMapperDecorator.php`: Verify both checkout and order have the surcharge methods before mapping

## Test plan

- [ ] Configure a Mollie payment method with a surcharge amount
- [ ] Go to checkout and select the Mollie payment method
- [ ] Verify the surcharge appears in the order totals
- [ ] Verify the surcharge is mapped from checkout to the created order

Closes #55