### PR TITLE
Feat: Pass cancelUrl to Mollie API for payment cancellation workflow

### DIFF
--- a/IntegrationCore/BusinessLogic/Http/OrgToken/ProxyDataProvider.php
+++ b/IntegrationCore/BusinessLogic/Http/OrgToken/ProxyDataProvider.php
@@ -144,6 +144,12 @@ class ProxyDataProvider
         // ensure that webhookUrl is same as on the order object
         $orderData['payment']['webhookUrl'] = $order->getWebhookUrl();
 
+        // Pass cancelUrl from metadata to the Mollie API payload
+        $metadata = $order->getMetadata();
+        if (isset($metadata['cancelUrl'])) {
+            $orderData['cancelUrl'] = $metadata['cancelUrl'];
+        }
+
         return $orderData;
     }
 

--- a/Mapper/MollieDtoMapper.php
+++ b/Mapper/MollieDtoMapper.php
@@ -221,6 +221,14 @@ class MollieDtoMapper implements MollieDtoMapperInterface
             }
         }
 
+        // Pass cancelUrl from OroCommerce payment transaction options to Mollie via metadata
+        $transactionOptions = $paymentTransaction->getTransactionOptions();
+        if (isset($transactionOptions['failureUrl'])) {
+            $metadata = $orderData->getMetadata() ?? [];
+            $metadata['cancelUrl'] = $this->ensureAbsoluteUrl($transactionOptions['failureUrl']);
+            $orderData->setMetadata($metadata);
+        }
+
         return $orderData;
     }
 
@@ -564,6 +572,27 @@ class MollieDtoMapper implements MollieDtoMapperInterface
             $orderLineData->setVatRate(
                 round(100 * (float)($taxesRow->getTaxAmount()) / (float)($taxesRow->getExcludingTax()), 2)
             );
+        }
+    }
+
+    /**
+     * Converts a potentially relative URL to an absolute URL as required by the Mollie API.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    protected function ensureAbsoluteUrl($url)
+    {
+        if (str_contains($url, '://')) {
+            return $url;
+        }
+
+        try {
+            return $this->router->generate('oro_frontend_root', [], UrlGeneratorInterface::ABSOLUTE_URL)
+                . ltrim($url, '/');
+        } catch (\Exception $e) {
+            return $url;
         }
     }
 


### PR DESCRIPTION
## Summary

- The Mollie Orders API supports a `cancelUrl` parameter that enables a cancel-specific redirect workflow
- Without it, customers who cancel a payment at Mollie have no clear path back to the checkout
- OroCommerce provides a `failureUrl` in `PaymentTransaction::getTransactionOptions()` for this purpose

## Changes

Two-part implementation using order metadata as a bridge between the mapper and proxy layers:

1. **`Mapper/MollieDtoMapper.php`**: Extracts `failureUrl` from transaction options, converts relative URLs to absolute (Mollie API requirement via new `ensureAbsoluteUrl()` helper), and stores as `cancelUrl` in order metadata
2. **`IntegrationCore/BusinessLogic/Http/OrgToken/ProxyDataProvider.php`**: Reads `cancelUrl` from metadata and promotes it to a top-level field in the API request payload

## Test plan

- [ ] Start checkout with any Mollie payment method
- [ ] On the Mollie payment page, cancel the payment
- [ ] Verify redirect back to the OroCommerce checkout (failure page)
- [ ] Verify successful payments are unaffected (redirectUrl still works normally)

Closes #56