### PR TITLE
Fix: Add .rendered guard to prevent synchronizationSettings double-render error

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -14,7 +14,7 @@
         {{ form_widget(form.parent.transport, {'attr': {'class': 'control-group-container'}}) }}
     {% endif %}
 
-    {% if (form.parent.synchronizationSettings is defined) %}
+    {% if (form.parent.synchronizationSettings is defined and not form.parent.synchronizationSettings.rendered) %}
         {{ form_widget(form.parent.synchronizationSettings) }}
     {% endif %}
 


### PR DESCRIPTION
## Summary

- The transport form template renders `form.parent.synchronizationSettings` without checking `.rendered`, causing a Twig double-render error on OroCommerce 6.1.x
- Oro's `logWarnings` sync setting (added without an `applicable` restriction) makes `synchronizationSettings.count > 0` for all integration types, triggering the conditional render in `update.html.twig` before Mollie's template renders the same field again

## Changes

- `Resources/views/Form/fields.html.twig`: Add `and not form.parent.synchronizationSettings.rendered` to the existing `is defined` check, matching the guard pattern used by Oro's own `IntegrationBundle/Resources/views/Form/fields.html.twig`

## Test plan

- [ ] Install on OroCommerce 6.1.x (with the `logWarnings` sync setting present)
- [ ] Create a new Mollie integration — verify no Twig error
- [ ] Edit an existing Mollie integration — verify no Twig error
- [ ] Verify the "Log warnings" checkbox appears in the Synchronization Settings section

Closes #61